### PR TITLE
Common docs layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,76 @@
+# FDC3 Pages Layout
+
+This repo contains the configuration to apply to any FDC3 repository that wants to publish documentation using GitHub Pages.
+
+Follow the steps below to configure your repository accordingly.
+
+## GitHub authentication
+
+In order to configure Travis CI to push changes to GitHub, it is necessary to collect:
+1. `GITHUB_USERNAME`, a GitHub username with write access to your FDC3 repository (specifically, the `gh-pages` branch)
+2. `GITHUB_EMAIL`, an email address related to the the GitHub username specified on #1
+3. `GITHUB_TOKEN`, a GitHub [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/); it needs to have `public_repo` permissions.
+
+## Enable Travis CI
+
+Travis CI must be configured with the instructions needed to generate and publish the documentation site.
+
+1. Please email help@finos.org with subject `Enable Travis CI for project github.com/fdc3/<repo name>` and we'll enable the CI environment for you.
+2. Install the [travis commandline client](https://github.com/travis-ci/travis.rb) and generate the encrypted versions of your GitHub username, email and access token, using the following commands:
+```
+travis encrypt GITHUB_TOKEN=....
+travis encrypt GITHUB_USERNAME=....
+travis encrypt GITHUB_PASSWORD=....
+```
+3. Paste the `- secure` items in your `.travis.yml`, along with the content in [travis.sample.yml](travis.sample.yml).
+
+## Integrate docs publishing in Travis CI
+
+All the following block in `.travis.yml`:
+```
+  - provider: script
+    skip_cleanup: true
+    script: curl https://raw.githubusercontent.com/fdc3/FDC3/master/docs/prepare-docs-release.sh | bash
+    on:
+      branch: branch
+```
+
+## Using a custom domain
+
+You can specify the custom domain you want to use for the documentation site publishing by defining a `docs/CNAME` file with the name of the domain, ie `fdc3-api.finos.org`.
+
+Checkout [GitHub Pages documentation](https://help.github.com/articles/setting-up-an-apex-domain/) to edit DNS configurations accordingly.
+
+## Run website locally
+To run the website documentation locally, please follow the steps below.
+
+### Install Ruby (MacOS)
+
+It is strongly advised to use RVM or RBenv to install Ruby; below are the steps to install RVM on MacOS.
+```
+mkdir -p ~/.rvm/src && cd ~/.rvm/src && rm -rf ./rvm && \
+git clone --depth 1 https://github.com/rvm/rvm.git && \
+cd rvm && ./install
+rvm install 2.5.2
+which bundle #Should return a .rvm sub-path
+which ruby #Should return a .rvm sub-path
+```
+
+### Install gems needed for jekyll
+
+```
+cd /tmp
+git clone https://github.com/pages-themes/slate
+cd slate
+rm -rf .bundle
+./script/bootstrap
+gem install jekyll-theme-slate
+gem install jekyll-seo-tag
+gem install jekyll-watch
+```
+
+# Run jekyll on other project
+```
+cd ../API/docs
+jekyll serve --incremental
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,33 @@ All the following block in `.travis.yml`:
       branch: branch
 ```
 
+## Configure semantic release
+
+Define the following elements in your `package.json` file.
+
+```
+  "release": {
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/git",
+      [
+        "@semantic-release/changelog",
+        {
+          "changelogFile": "docs/CHANGELOG.md.new"
+        }
+      ],
+      [
+        "@semantic-release/npm",
+        {
+          "npmPublish": false
+        }
+      ],
+      "@semantic-release/github"
+    ]
+  }
+```
+
 ## Using a custom domain
 
 You can specify the custom domain you want to use for the documentation site publishing by defining a `docs/CNAME` file with the name of the domain, ie `fdc3-api.finos.org`.

--- a/docs/prepare-docs-release.sh
+++ b/docs/prepare-docs-release.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+THEME_GIT_REPO="https://github.com/maoo/fdc3-pages-layout.git"
+
+PACKAGE_VERSION=$(cat package.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{ print $2 }' \
+  | sed 's/[",]//g' \
+  | tr -d '[:space:]')
+
+GH_REPO_LINE=$(cat package.json | grep repository)
+GH_REPO=$(echo ${GH_REPO_LINE#*:} | sed 's/[",]//g' | tr -d '[:space:]')
+
+# Copying images in docs/ folder and patching release version
+cp -Rf images/ docs/
+sed -i "s/\[\[tag\]\]/$PACKAGE_VERSION/g" docs/_config.yml
+echo "---\nflag: tags\n---" > ${PACKAGE_VERSION}.md
+echo "Updated _config.yml folder with version '$PACKAGE_VERSION'"
+
+# Pulling theme layout and assets
+git clone $THEME_GIT_REPO /tmp/theme-repo
+cp -rf /tmp/theme-repo/docs/theme/{_layouts,assets} docs/
+echo "Copied common _layouts and assets folders into docs/"
+
+# Pulling contents from gh-pages branch
+git clone $GH_REPO gh-pages-docs
+cd gh-pages-docs
+git checkout gh-pages
+rm -rf .git
+cd ..
+cp -f gh-pages-docs/CHANGELOG.md docs/
+echo "Cloned gh-pages branch"
+
+# Append new release notes at the top of CHANGELOG.md
+# Check package.json to see how CHANGELOG.md.new is created
+echo -e "$(cat docs/CHANGELOG.md.new)\n\n$(cat docs/CHANGELOG.md)" > docs/CHANGELOG.md
+rm -f docs/CHANGELOG.md.new
+echo "Updated docs/CHANGELOG.md"
+
+# Copy docs/ contents in a tag-specific subfolder, to allow access to docs history
+# Tags are configured as Jekyll collections in _config.yml
+mkdir -p gh-pages-docs/tags/$PACKAGE_VERSION
+cp -rf docs/* gh-pages-docs/tags/$PACKAGE_VERSION
+
+# Updating gh-pages branch root folder
+cp -rf docs/* gh-pages-docs/
+
+echo "Updated _config.yml folder with version '$PACKAGE_VERSION'"

--- a/docs/prepare-docs-release.sh
+++ b/docs/prepare-docs-release.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-THEME_GIT_REPO="https://github.com/maoo/fdc3-pages-layout.git"
+# TODO - replace with https://github.com/fdc3/FDC3.git before PR gets merged
+THEME_GIT_REPO="https://github.com/maoo/FDC3.git"
 
 PACKAGE_VERSION=$(cat package.json \
   | grep version \
@@ -19,7 +20,8 @@ echo "---\nflag: tags\n---" > ${PACKAGE_VERSION}.md
 echo "Updated _config.yml folder with version '$PACKAGE_VERSION'"
 
 # Pulling theme layout and assets
-git clone $THEME_GIT_REPO /tmp/theme-repo
+git clone --single-branch -b common-docs-layout $THEME_GIT_REPO /tmp/theme-repo
+# TODO - remove when merged to master
 cp -rf /tmp/theme-repo/docs/theme/{_layouts,assets} docs/
 echo "Copied common _layouts and assets folders into docs/"
 

--- a/docs/prepare-mvn-docs-release.sh
+++ b/docs/prepare-mvn-docs-release.sh
@@ -3,12 +3,19 @@
 # TODO - replace with https://github.com/fdc3/FDC3.git before PR gets merged
 THEME_GIT_REPO="https://github.com/maoo/FDC3.git"
 
-PACKAGE_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version |grep -Ev '(^\[|Download\w+:)')
+# PACKAGE_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version |grep -Ev '(^\[|Download\w+:)')
 
-GH_REPO="$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.scm.url |grep -Ev '(^\[|Download\w+:)').git"
+PACKAGE_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+
+# GH_REPO="$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.scm.url |grep -Ev '(^\[|Download\w+:)').git"
+
+GH_REPO="$(mvn -q -Dexec.executable=echo -Dexec.args='${project.scm.url}' --non-recursive exec:exec).git"
 
 # Copying images in docs/ folder and patching release version
-cp -Rf images/ docs/
+if [ -d "images/" ]; then
+	cp -Rf images/ docs/
+fi
+
 sed -i "s/\[\[tag\]\]/$PACKAGE_VERSION/g" docs/_config.yml
 echo "---\nflag: tags\n---" > ${PACKAGE_VERSION}.md
 echo "Updated _config.yml folder with version '$PACKAGE_VERSION'"
@@ -22,7 +29,9 @@ echo "Copied common _layouts and assets folders into docs/"
 # Pulling contents from gh-pages branch
 git clone $GH_REPO gh-pages-docs
 cd gh-pages-docs
-if [ `git branch --list gh-pages` ]; then
+echo "Branches"
+echo "$(git branch -r --list | grep gh-pages)"
+if [[ `git branch -r --list | grep gh-pages` ]]; then
 	git checkout gh-pages
 	echo "Cloned gh-pages branch"
 else

--- a/docs/prepare-mvn-docs-release.sh
+++ b/docs/prepare-mvn-docs-release.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# TODO - replace with https://github.com/fdc3/FDC3.git before PR gets merged
+THEME_GIT_REPO="https://github.com/maoo/FDC3.git"
+
+PACKAGE_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version |grep -Ev '(^\[|Download\w+:)')
+
+GH_REPO="$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.scm.url |grep -Ev '(^\[|Download\w+:)').git"
+
+# Copying images in docs/ folder and patching release version
+cp -Rf images/ docs/
+sed -i "s/\[\[tag\]\]/$PACKAGE_VERSION/g" docs/_config.yml
+echo "---\nflag: tags\n---" > ${PACKAGE_VERSION}.md
+echo "Updated _config.yml folder with version '$PACKAGE_VERSION'"
+
+# Pulling theme layout and assets
+git clone --single-branch -b common-docs-layout $THEME_GIT_REPO /tmp/theme-repo
+# TODO - remove when merged to master
+cp -rf /tmp/theme-repo/docs/theme/{_layouts,assets} docs/
+echo "Copied common _layouts and assets folders into docs/"
+
+# Pulling contents from gh-pages branch
+git clone $GH_REPO gh-pages-docs
+cd gh-pages-docs
+git checkout gh-pages
+rm -rf .git
+cd ..
+echo "Cloned gh-pages branch"
+
+# TODO - need to figure out how to integrate CHANGELOG in a Maven build
+#
+# Append new release notes at the top of CHANGELOG.md
+# Check package.json to see how CHANGELOG.md.new is created
+# cp -f gh-pages-docs/CHANGELOG.md docs/
+# echo -e "$(cat docs/CHANGELOG.md.new)\n\n$(cat docs/CHANGELOG.md)" > docs/CHANGELOG.md
+# rm -f docs/CHANGELOG.md.new
+# echo "Updated docs/CHANGELOG.md"
+
+# Copy docs/ contents in a tag-specific subfolder, to allow access to docs history
+# Tags are configured as Jekyll collections in _config.yml
+mkdir -p gh-pages-docs/tags/$PACKAGE_VERSION
+cp -rf docs/* gh-pages-docs/tags/$PACKAGE_VERSION
+
+# Updating gh-pages branch root folder
+cp -rf docs/* gh-pages-docs/
+
+echo "Updated _config.yml folder with version '$PACKAGE_VERSION'"

--- a/docs/prepare-mvn-docs-release.sh
+++ b/docs/prepare-mvn-docs-release.sh
@@ -22,10 +22,15 @@ echo "Copied common _layouts and assets folders into docs/"
 # Pulling contents from gh-pages branch
 git clone $GH_REPO gh-pages-docs
 cd gh-pages-docs
-git checkout gh-pages
+if [ `git branch --list gh-pages` ]; then
+	git checkout gh-pages
+	echo "Cloned gh-pages branch"
+else
+    rm -rf *
+    echo "no gh-pages branch found, this is the first doc deployment"
+fi
 rm -rf .git
 cd ..
-echo "Cloned gh-pages branch"
 
 # TODO - need to figure out how to integrate CHANGELOG in a Maven build
 #

--- a/docs/prepare-mvn-docs-release.sh
+++ b/docs/prepare-mvn-docs-release.sh
@@ -3,11 +3,7 @@
 # TODO - replace with https://github.com/fdc3/FDC3.git before PR gets merged
 THEME_GIT_REPO="https://github.com/maoo/FDC3.git"
 
-# PACKAGE_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version |grep -Ev '(^\[|Download\w+:)')
-
 PACKAGE_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
-
-# GH_REPO="$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.scm.url |grep -Ev '(^\[|Download\w+:)').git"
 
 GH_REPO="$(mvn -q -Dexec.executable=echo -Dexec.args='${project.scm.url}' --non-recursive exec:exec).git"
 
@@ -22,7 +18,6 @@ echo "Updated _config.yml folder with version '$PACKAGE_VERSION'"
 
 # Pulling theme layout and assets
 git clone --single-branch -b common-docs-layout $THEME_GIT_REPO /tmp/theme-repo
-# TODO - remove when merged to master
 cp -rf /tmp/theme-repo/docs/theme/{_layouts,assets} docs/
 echo "Copied common _layouts and assets folders into docs/"
 

--- a/docs/theme/_layouts/default.html
+++ b/docs/theme/_layouts/default.html
@@ -11,19 +11,19 @@
   <body>
     <ul class="nav nav-fill">
       <li class="nav-item">
-        <a class="nav-link" href="https://fdc3-app-directory.finos.org">API</a>
+        <a class="nav-link" id="api" href="https://fdc3-api.finos.org">API</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://fdc3-app-directory.finos.org">App Directory</a>
+        <a class="nav-link" id="app-directory" href="https://fdc3-app-directory.finos.org">App Directory</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://context-data.finos.org">Context Data</a>
+        <a class="nav-link" id="context-data" href="https://context-data.finos.org">Context Data</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://fdc3-intents.finos.org">Intents</a>
+        <a class="nav-link" id="intents" href="https://fdc3-intents.finos.org">Intents</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="https://fdc3-use-cases.finos.org">Use Case</a>
+        <a class="nav-link" id="use-case" href="https://fdc3-use-cases.finos.org">Use Case</a>
       </li>
     </ul>
     <!-- MAIN CONTENT -->

--- a/docs/theme/_layouts/default.html
+++ b/docs/theme/_layouts/default.html
@@ -17,13 +17,13 @@
         <a class="nav-link" id="app-directory" href="https://fdc3-app-directory.finos.org">App Directory</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" id="context-data" href="https://context-data.finos.org">Context Data</a>
+        <a class="nav-link" id="context-data" href="https://fdc3-context-data.finos.org">Context Data</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" id="intents" href="https://fdc3-intents.finos.org">Intents</a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" id="use-case" href="https://fdc3-use-cases.finos.org">Use Case</a>
+        <a class="nav-link" id="use-case" target="_blank" href="https://finosfoundation.atlassian.net/wiki/spaces/FDC3/pages/169738241/Use+Case+Working+Group">Use Case</a>
       </li>
     </ul>
     <!-- MAIN CONTENT -->

--- a/docs/theme/_layouts/default.html
+++ b/docs/theme/_layouts/default.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,maximum-scale=2">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+  </head>
+
+  <body>
+    <ul class="nav nav-fill">
+      <li class="nav-item">
+        <a class="nav-link" href="https://fdc3-app-directory.finos.org">API</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="https://fdc3-app-directory.finos.org">App Directory</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="https://context-data.finos.org">Context Data</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="https://fdc3-intents.finos.org">Intents</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="https://fdc3-use-cases.finos.org">Use Case</a>
+      </li>
+    </ul>
+    <!-- MAIN CONTENT -->
+    <div id="main_content_wrap container" class="outer">
+      <div class="row">
+        <div class="col-3 left-column">
+          <div class="column-menu">
+            <p class="column-title"><a href="https://finos.org/fdc3" target="_blank"><img src="https://www.finos.org/hs-fs/hubfs/FINOS/website/pages/programs/fdc3-logo.png" alt="FDC3 logo"/></a></p>
+            <div class="column-icons">
+              {% for social_icon in site.social_icons %}
+                <a href="{{ social_icon.link_url }}" target="_blank">
+                  <img src="{{ social_icon.image_url }}"/></a>
+              {% endfor %}
+            </div>
+            <ul class="column-menu">
+                <li>
+                  <a href="/CHANGELOG.html" target="{{ link.target }}">
+                    What's new in {{ site.version }}
+                  </a>
+                </li>
+                {% for link in site.links %}
+                  <li>
+                    <a href="{{ link.url }}" target="{{ link.target }}">
+                      {{ link.name }}
+                    </a>
+                  </li>
+                {% endfor %}
+                </ul>
+            </ul>
+          </div>
+          <div class="column-footer">
+            <a href="finos.org" target="_blank"><img src="https://www.finos.org/hs-fs/hubfs/sofin%20assets/SOFIN%20LOGOS/FINOS_Icon_Wordmark_White.png" alt="FINOS logo"/></a>
+            <p>Release: {{ site.version }}</p>
+            <a class="btn btn-primary" data-toggle="collapse" href="#collapseOldReleases" role="button" aria-expanded="false" aria-controls="collapseExample">
+              previous releases
+            </a>
+            <div class="collapse" id="collapseOldReleases">
+              <ul class="old-releases">
+                {% for page in site.pages %}
+                    {% if page.flag == 'tags' %}
+                      <li><a href="/tags/{{ page.name | remove: '.md'  }}">{{ page.name | remove: '.md' }}</a></li>
+                    {% endif %}
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+        </div>
+        <div class="col-9 main_content">
+          <section id="main_content" class="inner">
+            {{ content }}
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <!-- FOOTER  -->
+    <!-- <div id="footer_wrap" class="outer">
+      <footer class="inner">
+        {% if site.github.is_project_page %}
+        <p class="copyright">{{ site.title | default: site.github.repository_name }} maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
+        {% endif %}
+        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
+      </footer>
+    </div> -->
+
+    {% if site.google_analytics %}
+      <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+        ga('create', '{{ site.google_analytics }}', 'auto');
+        ga('send', 'pageview');
+      </script>
+    {% endif %}
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/docs/theme/assets/css/style.scss
+++ b/docs/theme/assets/css/style.scss
@@ -1,0 +1,112 @@
+---
+---
+
+html, body {
+    width:100%;
+    height:100%;
+    margin:0;
+}
+.outer, .row {
+	height:100%;
+}
+
+.inner {
+	margin: 30px;
+}
+
+.nav {
+    background-color: #322A38;
+}
+
+.nav a {
+	color: white;
+}
+
+.nav-link {
+    padding: .5rem 1rem;
+}
+
+.left-column {
+	padding-right: 0px !important;
+	background-color: #322A38 !important;
+}
+.main_content {
+	padding-left: 0px !important;
+	overflow-x: scroll;
+}
+
+.column-menu {
+	color:grey;
+	text-decoration: none;
+}
+.column-menu a {
+	color:grey;
+	text-decoration: none;
+}
+.column-menu a:visited {
+	color:grey;
+	text-decoration: none;
+}
+.column-menu a:hover {
+	text-decoration: none;
+	color:ligh-grey;
+}
+.column-menu img {
+	height: 100px;
+	margin: 0 20px 0 20px;
+	box-shadow: none !important;
+}
+
+.column-title {
+	margin-top: 20px;
+	text-align: center;
+}
+
+.column-icons img {
+	width: 48px;
+	height: 48px;
+}
+.column-icons {
+	text-align: center;
+}
+
+ul.column-menu {
+	padding-left: 0px !important;
+	padding-top: 20px !important;
+	margin-left: 40px;
+	font-size: 18px;
+}
+
+ul.old-releases {
+	list-style: none !important;
+}
+
+ul.column-menu li {
+	margin-bottom: 5px;
+	list-style: none !important;
+}
+
+.column-footer {
+	background-color: #63b7bf;
+	text-align: center;
+	padding-left: 15%;
+	padding-right: 15%;
+	padding-top: 5%;
+	padding-bottom: 5%;
+	color:white;
+	position: absolute;
+	width: 100%;
+	bottom: 0;
+	left: 0;
+}
+.column-footer h2 {
+	color: #ffffff !important;
+}
+.column-footer h3 {
+	background: none !important;
+}
+.column-footer img {
+	height: 100px;
+	margin: 10px;
+	box-shadow: none !important;
+}


### PR DESCRIPTION
In order to enable FDC3 Working Groups to quickly configure their documentation layout, I've used this repository to contain common resources:
- a script file that is used by Travis CI builds and prepare the contents to be published (`prepare-docs-release.sh`)
- common HTML/CSS layout (`default.html` and `style.scss`)
- documentation (`README.md`)

Check https://github.com/maoo/API to see it in action, specifically https://github.com/maoo/API/blob/common-layout/.travis.yml#L35