### PR TITLE
Switching domain (from fdc3.finos.org) to fdc3.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-fdc3.finos.org
+fdc3.org

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -23,8 +23,8 @@ const users = [
 const siteConfig = {
   title: 'FDC3', // Title for your website.
   tagline: 'Open standards for the financial desktop',
-  url: 'https://fdc3.finos.org',
-  cname: 'fdc3.finos.org',
+  url: 'https://fdc3.org',
+  cname: 'fdc3.org',
   baseUrl: '/',
   // For publishing to GitHub pages
   projectName: 'FDC3',


### PR DESCRIPTION
fdc3.org currently redirects to fdc3.finos.org . To complete the switch, it should be the other way around. This PR is to deploy docusaurus using fdc3.org as domain.

As soon as the PR is merged, I will make the DNS adjustments to finalize the change.

Read more on https://finosfoundation.atlassian.net/browse/ODP-79