### PR TITLE
Set FINOS badge to “Released” ahead of 1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/FDC3/FDC3.svg?branch=master)](https://travis-ci.org/FDC3/FDC3)
-[![FINOS - Incubating](https://cdn.rawgit.com/finos/contrib-toolbox/master/images/badge-incubating.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Incubating)
+[![FINOS - Released](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-released.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Released)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Stack Overflow](https://img.shields.io/badge/stackoverflow-tag-orange.svg)](https://stackoverflow.com/questions/tagged/fdc3)
+[![Stack Overflow](https://img.shields.io/badge/stackoverflow-fdc3-orange.svg)](https://stackoverflow.com/questions/tagged/fdc3)
 
 # FDC3
 


### PR DESCRIPTION
Relating to #32 release checklist for 1.0 release.

Also fix StackOverflow tag in badge