### PR TITLE
Context channels API proposal

### DIFF
--- a/examples/api/channels.ts
+++ b/examples/api/channels.ts
@@ -1,0 +1,22 @@
+const fdc3: DesktopAgent;
+
+async function channelExamples() {
+    
+    // ['blue', 'purple', 'green']
+    const allChannels = await fdc3.channels.list();
+
+    await fdc3.channels.update('blue', {
+        type: 'fdc3.contact',
+        name: 'Riko Eksteen',
+        id: {
+            email: 'riko@weareadaptive.com'
+        }
+    });
+
+    // called every time fdc3.contact type is updated on the blue channel
+    const contactListener = fdc3.channels.watch('blue', 'fdc3.contact', contact => {
+        console.log("Selected contact is" + contact.name);
+    });
+
+    contactListener.unsubscribe();
+};

--- a/src/api/channels.ts
+++ b/src/api/channels.ts
@@ -1,0 +1,17 @@
+interface Channels {
+
+    /**
+     * Retrieve a list of currently known channels
+     */
+    list(): Promise<string[]>;
+
+    /**
+     * Update a particular context value on a particular channel. Context values are indexed by their type.
+     */
+    update(channelName: string, context: Context): Promise<void>;
+
+    /**
+     * Watch for updates to a particular context type on a particular channel.
+     */
+    watch(channelName: string, type: string, handler: ContextHandler): Listener;
+}

--- a/src/api/interface.ts
+++ b/src/api/interface.ts
@@ -1,4 +1,5 @@
 type Context = object;
+type ContextHandler = (context: Context) => void;
 
 enum OpenError {
   AppNotFound = "AppNotFound",
@@ -174,4 +175,6 @@ interface DesktopAgent {
    * Adds a listener for incoming context broadcast from the Desktop Agent.
    */
   addContextListener(handler: (context: Context) => void): Listener;
+
+  channels: Channels;
 }


### PR DESCRIPTION
This API proposes a simple interface for dealing with channel updates / context sharing.

Some notes:
1. In this example channels are simply string names, but channels could potentially be richer objects
2. The first application to use a channel with a particular name (e.g. 'blue' or 'common') creates it.
3. Each channel represents a backing store of context objects indexed by their type. 
4. For each channel, you can have one "instrument" type, one "contact" type, etc. If a different "contact" type is pushed, this represents an updated value for that type.
5. The methods are deliberately not called "publish" and "subscribe" to indicate that there is a persistence store in play.

Some further topics to be discussed:
* Can context values be persisted between sessions?
* Should there be an option to retrieve only the current value without updates, or ignore the current value and only getting new updates.
* Should multiple different instances of the same type be supported on the same channel? (Gets complicated quickly...)
* Does it make sense for context channels to be defined as part of application definitions, the same way intents are?

Example use case (selecting a row in the blotter updates the context in other applications):

![Context Sharing](https://user-images.githubusercontent.com/3295115/55155289-dd15c080-514e-11e9-9294-8af4b33d68ab.png)
