### PR TITLE
Add CHANGELOG.md with standard format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2019-03-28
+
+First official release of FDC3 at https://fdc3.finos.org, consisting of:
+* [API Specification 1.0](https://fdc3.finos.org/docs/1.0/api/api-spec)
+* [Intents Specification 1.0](https://fdc3.finos.org/docs/1.0/intents-spec)
+* [Context Data Specification 1.0](https://fdc3.finos.org/docs/1.0/context-spec)
+* [App Directory Specification 1.0](https://fdc3.finos.org/docs/1.0/appd-spec)
+* [Use Cases 1.0](https://fdc3.finos.org/docs/1.0/use-cases/overview)
+
+Thank you to the following contributors who helped with this release:
+
+* @ColinEberhardt
+* @tschady
+* @donbasuno
+* @sbloodgood
+* @jonathanteperJPMC
+* @kjones207
+* @rikoe
+* @RichLinnell
+* @nkolba
+* @saori-tr
+
+### Added
+* Use Case 15 ([#49](https://github.com/FDC3/FDC3/pull/49))
+* FDC3 Roadmap ([#55](https://github.com/FDC3/FDC3/pull/55))
+* User showcase on website ([#67](https://github.com/FDC3/FDC3/pull/67))
+
+### Changed
+* Use case text on front page of website ([#54](https://github.com/FDC3/FDC3/pull/54))
+* Feature icons on website ([#57](https://github.com/FDC3/FDC3/pull/57))
+
+### Fixed
+* General cleanup of spelling, grammar and punctuation ([#34](https://github.com/FDC3/FDC3/pull/34))
+* Remove unnecessary dates from use case file names ([#41](https://github.com/FDC3/FDC3/pull/41))
+* Fix header colouring on responsive website ([#56](https://github.com/FDC3/FDC3/pull/56))
+* Fix workflow numbers in Use Case 1 ([#60](https://github.com/FDC3/FDC3/pull/60))
+* More proofreading changes to existing docs ([62](https://github.com/FDC3/FDC3/pull/62))
+* Fix examples in Intent Overview doc ([#65](https://github.com/FDC3/FDC3/pull/65))
+* Fix errors in DesktopAgent API doc ([#66](https://github.com/FDC3/FDC3/pull/66))
+* Add hyperlink to FDC3 Intro doc ([#69](https://github.com/FDC3/FDC3/pull/69))
+
+## [1.0.0-beta] - 2019-03-05
+
+Initial beta release of the combined FDC3 repository and the FDC3 website hosted at https://fdc3.finos.org.
+
+Thank you to the following contributors who helped with this release:
+* @nkolba
+* @rikoe
+* @espenove
+* @RichLinnell
+* @maoo
+* @brooklynrob
+
+## Added
+* API content from [FDC3/API](https://github.com/FDC3/API).
+* Intent content from [FDC3/Intents](https://github.com/FDC3/Intents).
+* Context Data content from [FDC3/ContextData](https://github.com/FDC3/ContextData).
+* App Directory content from [FDC3/appd-api](https://github.com/FDC3/appd-api).
+* Use Case content from [FDC3/use-cases](https://github.com/FDC3/use-cases).
+* Documentation website generated with [Docusaurus](https://docusaurus.io).
+
+
+[Unreleased]: https://github.com/FDC3/FDC3/compare/v1.0.0..HEAD
+[1.0.0]: https://github.com/FDC3/FDC3/compare/v1.0.0..v1.0.0-beta
+[1.0.0-beta]: https://github.com/FDC3/FDC3/releases/tag/v1.0.0-beta

--- a/website/pages/en/versions.js
+++ b/website/pages/en/versions.js
@@ -18,6 +18,7 @@ const versions = require(`${CWD}/versions.json`);
 function Versions(props) {
   const {config: siteConfig} = props;
   const latestVersion = versions[1]; // skip "stable" version to simulate permalinks for latest version
+  const latestGitVersion = latestVersion === "1.0" ? "1.0.0" : latestVersion;
   const pastVersions = versions.filter(version => version !== latestVersion && version !== 'stable');
   const repoUrl = `https://github.com/${siteConfig.organizationName}/${
     siteConfig.projectName
@@ -38,7 +39,7 @@ function Versions(props) {
                   <a href={`${siteConfig.baseUrl}${siteConfig.docsUrl}/${latestVersion}/fdc3-intro`}>Documentation</a>
                 </td>
                 <td>
-                  <a href={`${repoUrl}/releases/tag/v${latestVersion}`}>Release Notes</a>
+                  <a href={`${repoUrl}/releases/tag/v${latestGitVersion}`}>Release Notes</a>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
Resolves #46 and addresses #71.

Should make clear changes before v1.0.0-beta and changes in the lead up to v1.0.0.

Once this PR has been merged, the draft v1.0.0 tag can be published.