### PR TITLE
addIntentListener handler return type

### DIFF
--- a/docs/api/DesktopAgent.md
+++ b/docs/api/DesktopAgent.md
@@ -140,12 +140,13 @@ agent.raiseIntent("StartChat", newContext, intentR.source);
 
 ### `addIntentListener`
 ```typescript
-addIntentListener(intent: string, handler: (context: Context) => void): Listener;
+addIntentListener(intent: string, handler: (context: Context) => IntentListenerResponse): Listener;
 ```
  Adds a listener for incoming Intents from the Agent.
 #### See also
 * [`Listener`](#listener)
 * [`Context`](Context)
+* [`IntentListenerResponse`](#intentlistenerresponse)
 
 ### `addContextListener`
 ```typescript
@@ -213,6 +214,44 @@ var intentR = await agent.raiseIntent("intentName", context);
 //resolve a "Client-Service" type intent with data response
 var intentR = await agent.raiseIntent("intentName", context);
 var dataR = intentR.data;
+```
+
+### `IntentListenerResponse`
+
+```typescript
+type IntentListenerResponse = Promise<{data:any}> | void;
+```
+
+IntentListenerResponse describes the return type of an intent listener handler
+set up with addIntentListener.
+
+It's valid to not return anything at all, for "fire and forget" type intents,
+otherwise the handler must return a Promise that resolves to an object with a
+"data" property in it.
+ 
+#### Example
+```javascript
+// Valid
+agent.addIntentListener("IntentName", (context) => {
+  doSomething();
+});
+agent.addIntentListener("IntentName2", (context) => {
+  return Promise.resolve({
+    data: payload
+  });
+});
+
+// Invalid
+agent.addIntentListener("IntentName", (context) => {
+  return {
+    payload
+  };
+});
+agent.addIntentListener("IntentName", (context) => {
+  return Promise.resolve({
+    some: 'thing'
+  });
+});
 ```
 
 #### See also

--- a/src/api/interface.ts
+++ b/src/api/interface.ts
@@ -52,6 +52,36 @@ interface IntentResolution {
   version: string;
 }
 
+/**
+ * IntentListenerResponse describes the return type of an intent listener handler
+ * set up with addIntentListener.
+ * It's valid to not return anything at all, for "fire and forget" type intents,
+ * otherwise the handler must return a Promise that resolves to an object with a
+ * "data" property in it.
+ * ```javascript
+ * // Valid
+ * agent.addIntentListener("IntentName", (context) => {
+ *   doSomething();
+ * });
+ * agent.addIntentListener("IntentName2", (context) => {
+ *   return Promise.resolve({
+ *     data: payload
+ *   });
+ * });
+ *
+ * // Invalid
+ * agent.addIntentListener("IntentName", (context) => {
+ *   return {
+ *     payload
+ *   };
+ * });
+ * agent.addIntentListener("IntentName", (context) => {
+ *   return Promise.resolve({
+ *     some: 'thing'
+ *   });
+ * });
+ * ```
+ */
 type IntentListenerResponse = Promise<{data:any}> | void;
 
 interface Listener {

--- a/src/api/interface.ts
+++ b/src/api/interface.ts
@@ -52,6 +52,8 @@ interface IntentResolution {
   version: string;
 }
 
+type IntentListenerResponse = Promise<{data:any}> | void;
+
 interface Listener {
   /**
    * Unsubscribe the listener object.
@@ -168,7 +170,7 @@ interface DesktopAgent {
   /**
    * Adds a listener for incoming Intents from the Agent.
    */
-  addIntentListener(intent: string, handler: (context: Context) => void): Listener;
+  addIntentListener(intent: string, handler: (context: Context) => IntentListenerResponse): Listener;
 
   /**
    * Adds a listener for incoming context broadcast from the Desktop Agent.


### PR DESCRIPTION
If IntentResolution can have a data payload, it seems there's a missing data payload coming from the intent listener handler.

- It still accepts returning `void` as the simpler use case
- Otherwise it returns a `Promise`
- The Promise resolves to an object with a `data` property, instead of just `any`, to give the API room to grow.