### PR TITLE
Removing FactSet specfic examples

### DIFF
--- a/docs/context-spec.md
+++ b/docs/context-spec.md
@@ -154,6 +154,6 @@ The identifier "foo" is proprietary, an application that can use it is free to d
 ```json
 "id": {
     "CUSIP":"037833100",
-    "com.factset.symbology.entity": "000C7F-E"
+    "com.company.foo": "000C7F-E"
 }
 ```


### PR DESCRIPTION
In light of recent changes to the FO specification, I would like to remove the FactSet specific example. I also think the connection to the foo example above makes it even easier to understand.