### PR TITLE
 findIntentsForContext + assorted typos

### DIFF
--- a/docs/api/api-spec.md
+++ b/docs/api/api-spec.md
@@ -106,7 +106,7 @@ catch (er){
 ```
 
 ##### Upgrading to a Remote API Connection
-There are a wide range of workflows where decoupled intents and/or context passing do not provide rich enough interactivity and applications are better off exposing proprietary APIs.  In these cases, an App can use the *source* propoerty on the resolution of an intent to connect directly to another App and from there, call remote APIs using the methods available in the Desktop Agent context for the App.  For example: 
+There are a wide range of workflows where decoupled intents and/or context passing do not provide rich enough interactivity and applications are better off exposing proprietary APIs.  In these cases, an App can use the *source* property on the resolution of an intent to connect directly to another App and from there, call remote APIs using the methods available in the Desktop Agent context for the App.  For example: 
 
 ```javascript
     let chart = await agent.raiseIntent('ViewChart');
@@ -120,7 +120,7 @@ There are a wide range of workflows where decoupled intents and/or context passi
 Applications need to let the system know the Intents they can support.  Typically, this is done via registration with the App Directory.  It is also possible for Intents to be registered at the application level as well to support ad-hoc registration which may be helpful at development time.  While, dynamic registration is not part of this specification, a Desktop Agent agent may choose to support any number of registration paths.
 
 #### Compliance with Intent Standards
-Intents represent a contract with expected behavior if an app asserts that it supports the intent.  Where this contract is enforcable by schema (for example, return object types),the FDC3 API implementation should enforce compliance and return an error if the interface is not met.  
+Intents represent a contract with expected behavior if an app asserts that it supports the intent.  Where this contract is enforceable by schema (for example, return object types), the FDC3 API implementation should enforce compliance and return an error if the interface is not met.  
 
 It is expected that App Directories will also curate listed apps and ensure that they are complying with declared intents.
 

--- a/docs/appd-use.md
+++ b/docs/appd-use.md
@@ -12,7 +12,7 @@ identifiers, intents that provide contexts, and location of metadata providing
 information specific to the launching and integration of the application.
 
 In the real world the AppD would support many use cases as defined in the
-[FDC3 Use Cases](use-cases/use-cases-intro)
+[FDC3 Use Cases](use-cases/overview)
 
 The following provides some common use cases and benefits.
 

--- a/src/api/interface.ts
+++ b/src/api/interface.ts
@@ -122,7 +122,7 @@ interface DesktopAgent {
    *
    * ```javascript
    * // I have a context object, and I want to know what I can do with it, hence, I look for for intents...
-   * const appIntents = await agent.findIntentsForContext(context);
+   * const appIntents = await agent.findIntentsByContext(context);
    * 
    * // returns for example:
    * // [{


### PR DESCRIPTION
There seems to be one single reference to `findIntentsForContext` across the whole spec, whereas many to `findIntentsByContext` - I assumed that one was overlooked, so this PR fixes that, plus a couple of other random typos I spotted while reading through the docs.
