### PR TITLE
Added Chart IQ to users.json - display on Home

### DIFF
--- a/website/data/users.json
+++ b/website/data/users.json
@@ -6,6 +6,13 @@
         "isMember": false
     },
     {
+        "caption": "Chart IQ",
+        "image": "/img/users/ChartIQ.webp",
+        "infoLink": "https://www.chartiq.com/",
+        "pinned": true,
+        "isMember": true
+    },
+    {
         "caption": "FactSet",
         "image": "/img/users/FactSet.webp",
         "infoLink": "https://www.factset.com/",
@@ -60,5 +67,5 @@
         "infoLink": "https://www.scottlogic.com/",
         "pinned": true,
         "isMember": true
-    }
+    } 
 ]


### PR DESCRIPTION
Added Chart IQ to json file. Image was already loaded in in FDC3/website/static/img/users as ChartIQ.webp. Put in alphabetical order (looked like that is how the images were arranged).